### PR TITLE
This change makes it easier to get metadata on non-html urls

### DIFF
--- a/htmlmetadata/main.py
+++ b/htmlmetadata/main.py
@@ -19,7 +19,7 @@ def extract_metadata(url: str) -> dict:
     if url != response.geturl():
         metadata["request"]["redirects"] = response.geturl
 
-    metadata["request"]["headers"] = response.headers
+    metadata["request"]["headers"] = dict(response.headers)
 
     soup = BeautifulSoup(response.read(), "html5lib")
 

--- a/htmlmetadata/main.py
+++ b/htmlmetadata/main.py
@@ -19,7 +19,7 @@ def extract_metadata(url: str) -> dict:
     if url != response.geturl():
         metadata["request"]["redirects"] = response.geturl
 
-    metadata["request"]["headers"] = dict(response.headers)
+    metadata["request"]["headers"] = { **response.headers }
 
     soup = BeautifulSoup(response.read(), "html5lib")
 

--- a/htmlmetadata/main.py
+++ b/htmlmetadata/main.py
@@ -19,6 +19,8 @@ def extract_metadata(url: str) -> dict:
     if url != response.geturl():
         metadata["request"]["redirects"] = response.geturl
 
+    metadata["request"]["headers"] = response.headers
+
     soup = BeautifulSoup(response.read(), "html5lib")
 
     for group in Rules:
@@ -71,5 +73,9 @@ def extract_metadata(url: str) -> dict:
                 metadata["summary"]["image"] = schema["image"][0]
             else:
                 metadata["summary"]["image"] = schema["image"]
+
+    content_type = response.headers.get("Content-Type", "")
+    if "image" not in metadata["summary"] and content_type.startswith("image/"):
+        metadata["summary"]["image"] = response.geturl()
 
     return metadata


### PR DESCRIPTION
Description:

- Adds headers in metadata response
- If the content-type is an image, this will set the metadata['summary']['image'] to the url

This is from two issues I have:

- Some urls aren't pages, some are images, or something else. I still need metadata. 
- I'd also like to get the headers coming back like the Content-Type, Content-Length, etc.

I know this project is **HTML**metadata, but it was the best I found for getting info about a page. Thanks for that.
