### PR TITLE
Update main.py, redirects geturl() method not being called properly

### DIFF
--- a/htmlmetadata/main.py
+++ b/htmlmetadata/main.py
@@ -17,7 +17,7 @@ def extract_metadata(url: str) -> dict:
         raise Exception(f"Invalid response status {response.status!r}")
 
     if url != response.geturl():
-        metadata["request"]["redirects"] = response.geturl
+        metadata["request"]["redirects"] = response.geturl()
 
     metadata["request"]["headers"] = { **response.headers }
 


### PR DESCRIPTION
This line doesn't get what the method returns, it prints the HTTPResponse instance method string representation instead.

`{'request': {'url': 'http://google.es', 'redirects': <bound method HTTPResponse.geturl of <http.client.HTTPResponse object at 0x0000014641136850>>}`

Fixed after calling the function:

`{'request': {'url': 'http://google.es', 'redirects': 'http://www.google.es/'}`